### PR TITLE
Remove SNAPSHOT from release version

### DIFF
--- a/guja-appengine-ear/pom.xml
+++ b/guja-appengine-ear/pom.xml
@@ -3,12 +3,13 @@
     <parent>
         <artifactId>guja</artifactId>
         <groupId>com.wadpam.guja</groupId>
-        <version>0.8.13-SNAPSHOT</version>
+        <version>AF-1.0_0.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>guja-appengine-ear</artifactId>
+    <version>0.8.13</version>
     <packaging>ear</packaging>
 
     <build>

--- a/guja-appengine-war/pom.xml
+++ b/guja-appengine-war/pom.xml
@@ -4,12 +4,13 @@
     <parent>
         <groupId>com.wadpam.guja</groupId>
         <artifactId>guja</artifactId>
-        <version>0.8.13-SNAPSHOT</version>
+        <version>AF-1.0_0.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>guja-appengine-war</artifactId>
+        <version>0.8.13</version>
     <packaging>war</packaging>
 
 
@@ -46,24 +47,24 @@
         <dependency>
             <groupId>com.wadpam.guja</groupId>
             <artifactId>guja-core</artifactId>
-            <version>0.8.13-SNAPSHOT</version>
+            <version>0.8.13</version>
         </dependency>
 
         <dependency>
             <groupId>com.wadpam.guja</groupId>
             <artifactId>guja-base</artifactId>
-            <version>0.8.13-SNAPSHOT</version>
+            <version>AF-1.0_0.8.13</version>
         </dependency>
 
         <dependency>
             <groupId>com.wadpam.guja</groupId>
             <artifactId>guja-gae</artifactId>
-            <version>0.8.13-SNAPSHOT</version>
+            <version>0.8.13</version>
         </dependency>
         <dependency>
             <groupId>com.wadpam.guja</groupId>
             <artifactId>guja-contact</artifactId>
-            <version>0.8.13-SNAPSHOT</version>
+            <version>0.8.13</version>
         </dependency>
 
         <dependency>

--- a/guja-archetype/pom.xml
+++ b/guja-archetype/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wadpam.guja</groupId>
     <artifactId>guja-archetype</artifactId>
-    <version>0.8.13-SNAPSHOT</version>
+    <version>0.8.13</version>
     <packaging>maven-archetype</packaging>
 
     <build>

--- a/guja-base/pom.xml
+++ b/guja-base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>guja</artifactId>
         <groupId>com.wadpam.guja</groupId>
-        <version>0.8.13-SNAPSHOT</version>
+        <version>AF-1.0_0.8.13</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.wadpam.guja</groupId>
             <artifactId>guja-core</artifactId>
-            <version>0.8.13-SNAPSHOT</version>
+            <version>0.8.13</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/guja-contact/pom.xml
+++ b/guja-contact/pom.xml
@@ -3,11 +3,12 @@
     <parent>
         <artifactId>guja</artifactId>
         <groupId>com.wadpam.guja</groupId>
-        <version>0.8.13-SNAPSHOT</version>
+        <version>AF-1.0_0.8.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>guja-contact</artifactId>
+    <version>0.8.13</version>
     <packaging>jar</packaging>
 
     <name>guja-contact</name>
@@ -22,7 +23,7 @@
         <dependency>
             <groupId>com.wadpam.guja</groupId>
             <artifactId>guja-core</artifactId>
-            <version>0.8.13-SNAPSHOT</version>
+            <version>0.8.13</version>
         </dependency>
 
         <dependency>

--- a/guja-core/pom.xml
+++ b/guja-core/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>guja</artifactId>
         <groupId>com.wadpam.guja</groupId>
-        <version>0.8.13-SNAPSHOT</version>
+        <version>AF-1.0_0.8.13</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>guja-core</artifactId>
-
+    <version>0.8.13</version>	
     <packaging>jar</packaging>
 
     <!-- Specify hard-coded project properties here -->

--- a/guja-gae/pom.xml
+++ b/guja-gae/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>guja</artifactId>
         <groupId>com.wadpam.guja</groupId>
-        <version>0.8.13-SNAPSHOT</version>
+        <version>AF-1.0_0.8.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>guja-gae</artifactId>
-
+    <version>0.8.13</version>
     <packaging>jar</packaging>
 
     <!-- Specify hard-coded project properties here -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.wadpam.guja</groupId>
     <artifactId>guja</artifactId>
-    <version>AF-1.0-SNAPSHOT_GUJA-0.8.13-SNAPSHOT</version>
+    <version>AF-1.0_0.8.13</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
By convention, release versions are discouraged to be called SNAPSHOT.
Add AF to guja-base, but other modules that are not changed shall have original versioning.
This is to signal what sub-modules are changed by AF, now we can clearly see what sub-module is changed by AF.
